### PR TITLE
fix(detection): invert CheckUSBDevices logic to prevent false positives

### DIFF
--- a/internal/antivm/antivm.go
+++ b/internal/antivm/antivm.go
@@ -221,7 +221,7 @@ func (v *VMDetector) CheckUSBDevices() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return len(subKeys) > 0, nil
+	return len(subKeys) == 0, nil
 }
 
 // im not fan of this one, but its a good way to check if the user is a sandboxed user. 


### PR DESCRIPTION
Previously, the code returned `true` (VM Detected) if USB history was found (`len(subKeys) > 0`). Since almost all physical machines have a history of USB usage, this logic incorrectly flagged real computers as Virtual Machines. 


I inverted the check to `len(subKeys) == 0`. Now, the function correctly flags a system as a potential VM only if it has *zero* USB history.